### PR TITLE
Adds the manager roles to a different file

### DIFF
--- a/kubeproxy/config/manager/patches/apiserver_endpoint.patch.yaml
+++ b/kubeproxy/config/manager/patches/apiserver_endpoint.patch.yaml
@@ -10,6 +10,6 @@ spec:
       - name: manager
         env:
           - name: KUBERNETES_SERVICE_HOST
-            value: "172.17.0.2"
+            value: "172.17.0.3"
           - name: KUBERNETES_SERVICE_PORT
             value: "6443"

--- a/kubeproxy/config/rbac/kustomization.yaml
+++ b/kubeproxy/config/rbac/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- manager_role.yaml
+- manager_rolebinding.yaml
 # Comment the following 3 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/kubeproxy/config/rbac/manager_role.yaml
+++ b/kubeproxy/config/rbac/manager_role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: main-manager-role
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["events", "serviceaccounts"]
+  verbs: ["create", "patch", "update"]
+- apiGroups: ["apps", "extensions"]
+  resources: ["daemonsets"]
+  verbs: ["get", "watch", "list", "create", "patch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings"]
+  verbs: ["get", "watch", "list", "create"]
+- apiGroups: ["app.k8s.io"]
+  resources: ["applications"]
+  verbs: ["get", "watch", "list", "create", "patch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list", "watch"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]

--- a/kubeproxy/config/rbac/manager_rolebinding.yaml
+++ b/kubeproxy/config/rbac/manager_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: main-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: main-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: system

--- a/kubeproxy/main.go
+++ b/kubeproxy/main.go
@@ -57,6 +57,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "kubeproxy-operator",
 		Port:               9443,
 	})
 	if err != nil {


### PR DESCRIPTION
If the additionals are added to the `role.yaml` it gets delete when `make deploy` is run. This PR adds it to a separate file